### PR TITLE
Update default policy name for better identification

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "enable_ad_blocking" {
 variable "policy_name" {
   type        = string
   description = "Name for the ad-blocking policy"
-  default     = "Block Ads Terraform"
+  default     = "DNS-Block: Ads Gateway Terraform"
 }
 
 variable "policy_description" {


### PR DESCRIPTION
## Summary
- Updates the default policy name from `Block Ads Terraform` to `DNS-Block: Ads Gateway Terraform`
- Improves policy identification in the Cloudflare Zero Trust dashboard
- Follows consistent naming convention with DNS prefix

## Changes
- Modified `variables.tf` to update the default value for `policy_name` variable
- Maintains backward compatibility through variable configuration

## Impact
- Policy will be renamed on next Terraform apply
- No functional changes to ad-blocking behavior
- Better dashboard organization and identification

## Testing
- Configuration validated with `terraform validate`
- Plan shows expected policy name change
- No breaking changes to existing functionality