### PR TITLE
Add Terraform lock file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .terraform/
 terraform.tfstate*
 2-Terraform-cloudflare.code-workspace
+.terraform.lock.hcl
 
 # Ignore Terraform plan files
 *.tfplan


### PR DESCRIPTION
## Summary
- Adds `.terraform.lock.hcl` to the `.gitignore` file
- Prevents Terraform lock file conflicts in version control
- Aligns with Terraform best practices for team collaboration

## Changes
- Modified `.gitignore` to exclude `.terraform.lock.hcl`

## Rationale
Lock files can cause merge conflicts when different team members or CI/CD systems use different Terraform versions or provider versions. Including this in `.gitignore` prevents these conflicts while maintaining deterministic builds through Terraform Cloud.

## Impact
- No functional impact on Terraform execution
- Prevents future merge conflicts with lock files
- Follows HashiCorp recommended practices