### PR TITLE
Fix GitHub workflow context errors and add auto-merge functionality

### DIFF
--- a/.github/workflows/update-domain-lists.yml
+++ b/.github/workflows/update-domain-lists.yml
@@ -123,3 +123,23 @@ jobs:
             
             ### Next Steps
             After merging, Terraform will automatically update the Cloudflare Zero Trust lists.
+
+      - name: 🔀 Auto Squash and Merge PR
+        if: steps.create-pr.outputs.pull-request-operation == 'created' || steps.create-pr.outputs.pull-request-operation == 'updated'
+        run: |
+          # Extract PR number from the create-pull-request action output
+          PR_NUMBER="${{ steps.create-pr.outputs.pull-request-number }}"
+          if [ -z "$PR_NUMBER" ]; then
+            # Fallback: Get the most recent open PR for this workflow
+            PR_NUMBER=$(gh pr list --head "create-pull-request/patch" --state open --json number --jq '.[0].number')
+          fi
+          
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Merging PR #$PR_NUMBER"
+            gh pr merge "$PR_NUMBER" --squash
+          else
+            echo "No PR number found to merge"
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix invalid `github.run_started_at` context variables causing workflow errors
- Add complete auto-squash-merge functionality with fallback PR detection
- Improve date formatting in commit messages and PR descriptions

## Changes Made
- Replace `github.run_started_at` with valid context variables (`github.run_number`, `github.run_id`, `github.ref_name`)
- Add comprehensive auto-merge step with proper conditional logic
- Include fallback mechanism to detect PR number if primary method fails
- Clean up formatting and ensure proper workflow execution

## Test Plan
- [x] Workflow runs without context errors
- [x] PR creation works correctly with proper date formatting
- [x] Manual merge functionality confirmed working
- [ ] Auto-merge step to be tested after merge

🤖 Generated with [Claude Code](https://claude.ai/code)