### PR TITLE
🐛 fix: Add GH_TOKEN environment variable for workflow PR merge step

### DIFF
--- a/.github/workflows/update-domain-lists.yml
+++ b/.github/workflows/update-domain-lists.yml
@@ -134,6 +134,7 @@ jobs:
       - name: 🔀 Auto Squash and Merge PR
         if: steps.create-pr.outputs.pull-request-operation == 'created' || steps.create-pr.outputs.pull-request-operation == 'updated'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: |
           # Extract PR number from the create-pull-request action output


### PR DESCRIPTION
Fixes the update-domain-lists workflow failure by adding the required GH_TOKEN environment variable to the auto-merge step.

The workflow was failing with:


This change adds `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the environment variables in the merge step, allowing the `gh pr merge` command to authenticate properly.