### PR TITLE
🐛 fix: Enable auto-merge for workflow PRs to respect branch protection

### DIFF
--- a/.github/workflows/update-domain-lists.yml
+++ b/.github/workflows/update-domain-lists.yml
@@ -145,8 +145,8 @@ jobs:
           fi
           
           if [ -n "$PR_NUMBER" ]; then
-            echo "Merging PR #$PR_NUMBER"
-            gh pr merge "$PR_NUMBER" --squash
+            echo "Enabling auto-merge for PR #$PR_NUMBER"
+            gh pr merge "$PR_NUMBER" --squash --auto
           else
             echo "No PR number found to merge"
             exit 1


### PR DESCRIPTION
## Summary
This PR fixes the update-domain-lists workflow by enabling auto-merge functionality instead of attempting immediate merge, allowing the workflow to respect branch protection rules.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- Modified workflow merge step to use `--auto` flag instead of immediate merge
- Changed echo message to reflect auto-merge enablement
- Maintains automated workflow functionality while respecting repository security policies

## Problem Solved
The workflow was failing with "base branch policy prohibits the merge" error because it was trying to merge PRs immediately without waiting for required checks to pass. This change enables auto-merge, which will automatically merge the PR once all branch protection requirements are satisfied.

## Testing
- [x] Terraform formatting and validation passes
- [x] Workflow file syntax is valid
- [ ] Will be tested when workflow runs automatically

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Branch protection rules respected
- [x] Maintains automated workflow functionality