### PR TITLE
🔧 chore: Add personal identifier to policy name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "enable_ad_blocking" {
 variable "policy_name" {
   type        = string
   description = "Name for the ad-blocking policy"
-  default     = "DNS-Block: Ads Gateway Terraform"
+  default     = "DNS-Block: Ads Gateway Terraform [perso]"
 }
 
 variable "policy_description" {


### PR DESCRIPTION
## Summary
Add `[perso]` suffix to the default policy name to distinguish personal ad-blocking gateway policy from other potential deployments.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Configuration update

## Changes Made
- Modified `variables.tf` to add `[perso]` identifier to `policy_name` default value
- Updated default policy name from `"DNS-Block: Ads Gateway Terraform"` to `"DNS-Block: Ads Gateway Terraform [perso]"`

## Testing
- [x] TFLint validation passed
- [x] Terraform formatting check passed
- [x] Terraform configuration validation passed

## Impact
This is a cosmetic change to the default variable value. It does not affect existing deployments unless the variable is explicitly set to use the default value. The change helps distinguish personal deployments in the Cloudflare dashboard.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass
- [x] No documentation update needed (minor config change)